### PR TITLE
Fix/62 enums

### DIFF
--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/HyperApiProcessor.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/HyperApiProcessor.java
@@ -285,7 +285,15 @@ public class HyperApiProcessor extends AbstractProcessor {
         // Copy all enum constants
         for (Element enclosed : enumElement.getEnclosedElements()) {
             if (enclosed.getKind() == ElementKind.ENUM_CONSTANT) {
-                enumDtoBuilder.addEnumConstant(enclosed.getSimpleName().toString());
+                String constName = enclosed.getSimpleName().toString();
+                TypeSpec.Builder enumConstantBuilder = TypeSpec.anonymousClassBuilder("");
+
+                // Mirror field-level annotations
+                for (AnnotationMirror annotation : enclosed.getAnnotationMirrors()) {
+                    enumConstantBuilder.addAnnotation(AnnotationSpec.get(annotation));
+                }
+
+                enumDtoBuilder.addEnumConstant(constName, enumConstantBuilder.build());
             }
         }
 
@@ -403,6 +411,10 @@ public class HyperApiProcessor extends AbstractProcessor {
                                                                         ClassName.get("com.fasterxml.jackson.annotation", "JsonProperty"))
                                                                 .addMember("value", "$S", fieldName)
                                                                 .build());
+//                                // Mirror class level annotations
+//                                for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+//                                    fieldBuilder.addAnnotation(AnnotationSpec.get(annotationMirror));
+//                                }
 
                                 dtoBuilder.addField(fieldBuilder.build());
                                 allFields.add(field);

--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/HyperApiProcessor.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/HyperApiProcessor.java
@@ -42,6 +42,7 @@ import jakarta.annotation.Generated;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.QueryParam;
+
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -71,6 +72,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
@@ -101,1103 +103,1176 @@ import javax.tools.Diagnostic;
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 public class HyperApiProcessor extends AbstractProcessor {
 
-  /**
-   * Fully qualified name of the base entity class required for `@HyperResource` annotations.
-   */
-  public static final String DEV_HYPERAPI_RUNTIME_CORE_ENTITY = "com.eorghe.hyperapi.model.HyperEntity";
-  /**
-   * Fully qualified name of the base DTO class used for generated DTOs.
-   */
-  public static final String DEV_HYPERAPI_RUNTIME_CORE_ENTITY_DTO = "com.eorghe.hyperapi.dto.HyperDto";
+    /**
+     * Fully qualified name of the base entity class required for `@HyperResource` annotations.
+     */
+    public static final String DEV_HYPERAPI_RUNTIME_CORE_ENTITY = "com.eorghe.hyperapi.model.HyperEntity";
+    /**
+     * Fully qualified name of the base DTO class used for generated DTOs.
+     */
+    public static final String DEV_HYPERAPI_RUNTIME_CORE_ENTITY_DTO = "com.eorghe.hyperapi.dto.HyperDto";
 
-  private Filer filer;
-  private Messager messager;
-  private Elements elementUtils;
+    private Filer filer;
+    private Messager messager;
+    private Elements elementUtils;
 
-  /**
-   * Initializes the annotation processor with the processing environment.
-   *
-   * @param env the processing environment provided by the compiler
-   */
-  @Override
-  public synchronized void init(ProcessingEnvironment env) {
-    super.init(env);
-    filer = env.getFiler();
-    messager = env.getMessager();
-    elementUtils = env.getElementUtils();
-  }
-
-  /**
-   * Processes the `@HyperResource` annotations and generates the required code.
-   *
-   * @param annotations the set of annotations to process
-   * @param roundEnv    the environment for the current processing round
-   * @return true if the annotations were processed successfully, false otherwise
-   */
-  @Override
-  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    for (Element annotatedElement : roundEnv.getElementsAnnotatedWith(HyperResource.class)) {
-      if (!(annotatedElement instanceof TypeElement entityType)) {
-        error(annotatedElement, "@HyperResource must annotate a class.");
-        continue;
-      }
-
-      // 2. Check BaseEntity inheritance
-      if (!isExtendingBaseEntity(entityType)) {
-        error(
-            entityType,
-            "Class %s must extend %s to use @HyperResource",
-            DEV_HYPERAPI_RUNTIME_CORE_ENTITY,
-            entityType.getSimpleName().toString());
-        return false;
-      }
-
-      HyperResource hyperResource = entityType.getAnnotation(HyperResource.class);
-      String dtoName = sanitizeDtoName(entityType.getSimpleName().toString(), hyperResource.dto());
-      List<String> ignoredFields = Arrays.asList(hyperResource.mapping().ignore());
-      List<String> ignoredNestedFields = Arrays.asList(hyperResource.mapping().ignoreNested());
-
-      boolean shouldGenerate = !dtoName.isBlank() || !ignoredFields.isEmpty();
-      if (!shouldGenerate) {
-        info(entityType, "Skipping generation for " + entityType.getSimpleName());
-        continue;
-      }
-
-      try {
-        generateDTO(entityType, dtoName, ignoredFields);
-        generateMapper(entityType, dtoName, ignoredFields, ignoredNestedFields);
-        generateService(entityType, dtoName, hyperResource);
-        generateController(entityType, dtoName, hyperResource);
-      } catch (IOException | ClassNotFoundException e) {
-        error(entityType, "Code generation failed: " + e.getMessage());
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Checks if the given class extends the base entity class.
-   *
-   * @param typeElement the class to check
-   * @return true if the class extends the base entity, false otherwise
-   */
-  private boolean isExtendingBaseEntity(TypeElement typeElement) {
-    // 1. Get BaseEntity type
-    TypeElement baseEntityType =
-        elementUtils.getTypeElement(DEV_HYPERAPI_RUNTIME_CORE_ENTITY);
-
-    if (baseEntityType == null) {
-      error(typeElement, "Could not resolve BaseEntity class in classpath");
-      return false;
+    /**
+     * Initializes the annotation processor with the processing environment.
+     *
+     * @param env the processing environment provided by the compiler
+     */
+    @Override
+    public synchronized void init(ProcessingEnvironment env) {
+        super.init(env);
+        filer = env.getFiler();
+        messager = env.getMessager();
+        elementUtils = env.getElementUtils();
     }
 
-    // 2. Check inheritance
-    return typeElement
-        .getSuperclass()
-        .toString()
-        .equals(baseEntityType.getQualifiedName().toString());
-  }
+    /**
+     * Processes the `@HyperResource` annotations and generates the required code.
+     *
+     * @param annotations the set of annotations to process
+     * @param roundEnv    the environment for the current processing round
+     * @return true if the annotations were processed successfully, false otherwise
+     */
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (Element annotatedElement : roundEnv.getElementsAnnotatedWith(HyperResource.class)) {
+            if (!(annotatedElement instanceof TypeElement entityType)) {
+                error(annotatedElement, "@HyperResource must annotate a class.");
+                continue;
+            }
 
-  /**
-   * Generates the Mapper class for the given entity.
-   *
-   * @param entity       the entity TypeElement
-   * @param dtoName      the name of the DTO to generate
-   * @param ignore       the list of fields to ignore in mapping
-   * @param ignoreNested the list of nested fields to ignore in mapping
-   * @throws IOException if there is an error writing the generated file
-   */
-  private void generateMapper(
-      TypeElement entity, String dtoName, List<String> ignore, List<String> ignoreNested)
-      throws IOException {
-    String entityName = entity.getSimpleName().toString();
-    String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
-    String mapperName = entityName + "Mapper";
+            // 2. Check BaseEntity inheritance
+            if (!isExtendingBaseEntity(entityType)) {
+                error(
+                        entityType,
+                        "Class %s must extend %s to use @HyperResource",
+                        DEV_HYPERAPI_RUNTIME_CORE_ENTITY,
+                        entityType.getSimpleName().toString());
+                return false;
+            }
 
-    ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
-    ClassName entityClass = ClassName.get(basePackage, entityName);
+            HyperResource hyperResource = entityType.getAnnotation(HyperResource.class);
+            String dtoName = sanitizeDtoName(entityType.getSimpleName().toString(), hyperResource.dto());
+            List<String> ignoredFields = Arrays.asList(hyperResource.mapping().ignore());
+            List<String> ignoredNestedFields = Arrays.asList(hyperResource.mapping().ignoreNested());
 
-    TypeName superType =
-        ParameterizedTypeName.get(
-            ClassName.get("com.eorghe.hyperapi.mapper", "AbstractMapper"),
-            dtoClass,
-            entityClass);
+            boolean shouldGenerate = !dtoName.isBlank() || !ignoredFields.isEmpty();
+            if (!shouldGenerate) {
+                info(entityType, "Skipping generation for " + entityType.getSimpleName());
+                continue;
+            }
 
-    // Build @Mapping annotations for both directions
-    List<AnnotationSpec> mappingAnnotations = new ArrayList<>();
-
-    for (String nested : ignoreNested) {
-      mappingAnnotations.add(
-          AnnotationSpec.builder(ClassName.get("org.mapstruct", "Mapping"))
-              .addMember("target", "$S", nested)
-              .addMember("ignore", "true")
-              .build());
+            try {
+                generateDTO(entityType, dtoName, ignoredFields);
+                generateMapper(entityType, dtoName, ignoredFields, ignoredNestedFields);
+                generateService(entityType, dtoName, hyperResource);
+                generateController(entityType, dtoName, hyperResource);
+            } catch (IOException | ClassNotFoundException e) {
+                error(entityType, "Code generation failed: " + e.getMessage());
+            }
+        }
+        return true;
     }
 
-    // toEntity method
-    MethodSpec.Builder toEntityBuilder =
-        MethodSpec.methodBuilder("toEntity")
-            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-            .returns(entityClass)
-            .addParameter(dtoClass, "dto");
-    mappingAnnotations.forEach(toEntityBuilder::addAnnotation);
+    /**
+     * Checks if the given class extends the base entity class.
+     *
+     * @param typeElement the class to check
+     * @return true if the class extends the base entity, false otherwise
+     */
+    private boolean isExtendingBaseEntity(TypeElement typeElement) {
+        // 1. Get BaseEntity type
+        TypeElement baseEntityType =
+                elementUtils.getTypeElement(DEV_HYPERAPI_RUNTIME_CORE_ENTITY);
 
-    // toDto method
-    MethodSpec.Builder toDtoBuilder =
-        MethodSpec.methodBuilder("toDto")
-            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-            .returns(dtoClass)
-            .addParameter(entityClass, "entity");
-    mappingAnnotations.forEach(toDtoBuilder::addAnnotation);
+        if (baseEntityType == null) {
+            error(typeElement, "Could not resolve BaseEntity class in classpath");
+            return false;
+        }
 
-    // Abstract class builder
-    TypeSpec mapperClass =
-        TypeSpec.classBuilder(mapperName)
-            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-            .addAnnotation(generatedAnnotation())
-            .addAnnotation(
-                AnnotationSpec.builder(ClassName.get("org.mapstruct", "Mapper"))
-                    .addMember("componentModel", "$S", "cdi")
-                    .build())
-            .superclass(superType)
-            .addMethod(toEntityBuilder.build())
-            .addMethod(toDtoBuilder.build())
-            .build();
+        // 2. Check inheritance
+        return typeElement
+                .getSuperclass()
+                .toString()
+                .equals(baseEntityType.getQualifiedName().toString());
+    }
 
-    JavaFile.builder(basePackage + ".mapper", mapperClass).indent("    ").build().writeTo(filer);
-  }
+    /**
+     * Generates the Mapper class for the given entity.
+     *
+     * @param entity       the entity TypeElement
+     * @param dtoName      the name of the DTO to generate
+     * @param ignore       the list of fields to ignore in mapping
+     * @param ignoreNested the list of nested fields to ignore in mapping
+     * @throws IOException if there is an error writing the generated file
+     */
+    private void generateMapper(
+            TypeElement entity, String dtoName, List<String> ignore, List<String> ignoreNested)
+            throws IOException {
+        String entityName = entity.getSimpleName().toString();
+        String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
+        String mapperName = entityName + "Mapper";
 
-  /**
-   * Generates a DTO class for the given entity.
-   *
-   * @param entity  the entity TypeElement
-   * @param dtoName the name of the DTO to generate
-   * @param ignore  the list of fields to ignore in the DTO
-   * @throws IOException            if there is an error writing the generated file
-   * @throws ClassNotFoundException if the base DTO class cannot be found
-   */
-  private void generateDTO(TypeElement entity, String dtoName, List<String> ignore)
-      throws IOException, ClassNotFoundException {
-    String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
-    ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
-    ClassName baseDtoClass = ClassName.bestGuess(DEV_HYPERAPI_RUNTIME_CORE_ENTITY_DTO);
+        ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
+        ClassName entityClass = ClassName.get(basePackage, entityName);
 
-    // Initialize builder with common configurations
-    TypeSpec.Builder dtoBuilder =
-        TypeSpec.classBuilder(dtoClass)
-            .addModifiers(Modifier.PUBLIC)
-            .superclass(baseDtoClass)
-            .addAnnotation(generatedAnnotation())
-            .addAnnotation(
-                AnnotationSpec.builder(
-                        ClassName.get("com.fasterxml.jackson.annotation", "JsonInclude"))
-                    .addMember(
-                        "value",
-                        "$T.Include.NON_NULL",
-                        ClassName.get("com.fasterxml.jackson.annotation", "JsonInclude"))
-                    .build());
+        TypeName superType =
+                ParameterizedTypeName.get(
+                        ClassName.get("com.eorghe.hyperapi.mapper", "AbstractMapper"),
+                        dtoClass,
+                        entityClass);
 
-    // Track fields for potential builder pattern
-    List<Element> allFields = new ArrayList<>();
+        // Build @Mapping annotations for both directions
+        List<AnnotationSpec> mappingAnnotations = new ArrayList<>();
 
-    // Process all fields
-    for (Element field : entity.getEnclosedElements()) {
-      if (field.getKind() == ElementKind.FIELD
-          && !ignore.contains(field.getSimpleName().toString())) {
-        String fieldName = field.getSimpleName().toString();
-        TypeMirror fieldType = field.asType();
+        for (String nested : ignoreNested) {
+            mappingAnnotations.add(
+                    AnnotationSpec.builder(ClassName.get("org.mapstruct", "Mapping"))
+                            .addMember("target", "$S", nested)
+                            .addMember("ignore", "true")
+                            .build());
+        }
 
-        // Convert entity types to DTO types
-        TypeName dtoFieldTypeName = convertEntityTypeToDto(fieldType, basePackage);
+        // toEntity method
+        MethodSpec.Builder toEntityBuilder =
+                MethodSpec.methodBuilder("toEntity")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(entityClass)
+                        .addParameter(dtoClass, "dto");
+        mappingAnnotations.forEach(toEntityBuilder::addAnnotation);
 
-        // Add the field with Jackson annotations
-        FieldSpec.Builder fieldBuilder =
-                FieldSpec.builder(dtoFieldTypeName, fieldName, Modifier.PRIVATE)
+        // toDto method
+        MethodSpec.Builder toDtoBuilder =
+                MethodSpec.methodBuilder("toDto")
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .returns(dtoClass)
+                        .addParameter(entityClass, "entity");
+        mappingAnnotations.forEach(toDtoBuilder::addAnnotation);
+
+        // Abstract class builder
+        TypeSpec mapperClass =
+                TypeSpec.classBuilder(mapperName)
+                        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                        .addAnnotation(generatedAnnotation())
+                        .addAnnotation(
+                                AnnotationSpec.builder(ClassName.get("org.mapstruct", "Mapper"))
+                                        .addMember("componentModel", "$S", "cdi")
+                                        .build())
+                        .superclass(superType)
+                        .addMethod(toEntityBuilder.build())
+                        .addMethod(toDtoBuilder.build())
+                        .build();
+
+        JavaFile.builder(basePackage + ".mapper", mapperClass).indent("    ").build().writeTo(filer);
+    }
+
+
+    private TypeSpec generateEnumDTO(Element enumElement) throws IOException {
+        String enumName = enumElement.getSimpleName().toString();
+        String dtoName = enumName + "DTO";
+        String basePackage = elementUtils.getPackageOf(enumElement).getQualifiedName().toString();
+
+        TypeSpec.Builder enumDtoBuilder = TypeSpec.enumBuilder(dtoName)
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(generatedAnnotation());
+
+        // Copy all enum constants
+        for (Element enclosed : enumElement.getEnclosedElements()) {
+            if (enclosed.getKind() == ElementKind.ENUM_CONSTANT) {
+                enumDtoBuilder.addEnumConstant(enclosed.getSimpleName().toString());
+            }
+        }
+
+        // Copy class-level annotations (like Jackson annotations)
+        for (AnnotationMirror annotation : enumElement.getAnnotationMirrors()) {
+            enumDtoBuilder.addAnnotation(AnnotationSpec.get(annotation));
+        }
+
+        TypeSpec enumDto = enumDtoBuilder.build();
+
+        JavaFile.builder(basePackage, enumDto)
+                .indent("    ")
+                .build()
+                .writeTo(filer);
+
+        return enumDto;
+    }
+
+    /**
+     * Generates a DTO class for the given entity.
+     *
+     * @param entity  the entity TypeElement
+     * @param dtoName the name of the DTO to generate
+     * @param ignore  the list of fields to ignore in the DTO
+     * @throws IOException            if there is an error writing the generated file
+     * @throws ClassNotFoundException if the base DTO class cannot be found
+     */
+    private void generateDTO(TypeElement entity, String dtoName, List<String> ignore)
+            throws IOException, ClassNotFoundException {
+        String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
+        ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
+        ClassName baseDtoClass = ClassName.bestGuess(DEV_HYPERAPI_RUNTIME_CORE_ENTITY_DTO);
+
+        // Initialize builder with common configurations
+        TypeSpec.Builder dtoBuilder =
+                TypeSpec.classBuilder(dtoClass)
+                        .addModifiers(Modifier.PUBLIC)
+                        .superclass(baseDtoClass)
+                        .addAnnotation(generatedAnnotation())
                         .addAnnotation(
                                 AnnotationSpec.builder(
-                                                ClassName.get("com.fasterxml.jackson.annotation", "JsonProperty"))
-                                        .addMember("value", "$S", fieldName)
+                                                ClassName.get("com.fasterxml.jackson.annotation", "JsonInclude"))
+                                        .addMember(
+                                                "value",
+                                                "$T.Include.NON_NULL",
+                                                ClassName.get("com.fasterxml.jackson.annotation", "JsonInclude"))
                                         .build());
 
-        // Handle initialization for collections
-        if (PropertyGenerator.isCollectionType(fieldType)) {
-          fieldBuilder.initializer("new $T<>()", getCollectionImplType(fieldType));
+        // Track fields for potential builder pattern
+        List<Element> allFields = new ArrayList<>();
+
+        // Process all fields
+        for (Element field : entity.getEnclosedElements()) {
+            if (field.getKind() == ElementKind.FIELD
+                    && !ignore.contains(field.getSimpleName().toString())) {
+
+                // Find ENUM fields.
+                TypeMirror fieldType = field.asType();
+                String fieldName = field.getSimpleName().toString();
+
+                boolean isEnum = false;
+                if (fieldType.getKind() == TypeKind.DECLARED) {
+                    Element element = ((DeclaredType) fieldType).asElement();
+                    if (element.getKind() == ElementKind.ENUM) {
+                        isEnum = true;
+                    }
+                }
+
+
+                if (!isEnum) {
+                    // Convert entity types to DTO types
+                    TypeName dtoFieldTypeName = convertEntityTypeToDto(fieldType, basePackage);
+
+                    // Add the field with Jackson annotations
+                    FieldSpec.Builder fieldBuilder =
+                            FieldSpec.builder(dtoFieldTypeName, fieldName, Modifier.PRIVATE)
+                                    .addAnnotation(
+                                            AnnotationSpec.builder(
+                                                            ClassName.get("com.fasterxml.jackson.annotation", "JsonProperty"))
+                                                    .addMember("value", "$S", fieldName)
+                                                    .build());
+
+                    // Handle initialization for collections
+                    if (PropertyGenerator.isCollectionType(fieldType)) {
+                        fieldBuilder.initializer("new $T<>()", getCollectionImplType(fieldType));
+                    }
+
+                    dtoBuilder.addField(fieldBuilder.build());
+                    allFields.add(field);
+
+                    // Generate all appropriate methods with converted DTO types
+                    PropertyGenerator.addPropertyMethods(dtoBuilder, fieldName, dtoFieldTypeName, field.getModifiers());
+                } else {
+                    // Generate Enum DTO
+                    if (fieldType.getKind() == TypeKind.DECLARED) {
+                        Element element = ((DeclaredType) fieldType).asElement();
+                        if (element.getKind() == ElementKind.ENUM) {
+                            // Define the field with the proper DTO
+//                            String generatedEnumDtoName =
+                            TypeName className = TypeName.get(generateEnumDTO(element).getClass());
+
+                            // Add the field with Jackson annotations
+                            FieldSpec.Builder fieldBuilder =
+                                    FieldSpec.builder(className, fieldName, Modifier.PRIVATE)
+                                            .addAnnotation(
+                                                    AnnotationSpec.builder(
+                                                                    ClassName.get("com.fasterxml.jackson.annotation", "JsonProperty"))
+                                                            .addMember("value", "$S", fieldName)
+                                                            .build());
+
+                            dtoBuilder.addField(fieldBuilder.build());
+                            allFields.add(field);
+                        }
+
+                    }
+
+
+                }
+
+            }
         }
 
-        dtoBuilder.addField(fieldBuilder.build());
-        allFields.add(field);
-
-        // Generate all appropriate methods with converted DTO types
-        PropertyGenerator.addPropertyMethods(dtoBuilder, fieldName, dtoFieldTypeName, field.getModifiers());
-      }
-    }
-    if (allFields.isEmpty()) {
-      String wanrMessage =
-          "%s : The class doesn't contain any fields to generate DTO for. "
-              + "Ensure it has fields annotated with @HyperResource or not ignored by mapping.";
-      warn(entity, wanrMessage, entity.getQualifiedName().toString());
-    }
-
-    // Add toString(), equals() and hashCode()
-    addCommonMethods(dtoBuilder, allFields, dtoName, entity.getSimpleName().toString());
-
-    // Add builder pattern if needed
-    // FIXME the mapper wont create proper toDto method
-    //        if (generateBuilder) {
-    //        PropertyGenerator.addBuilderSupport(dtoBuilder, allFields, dtoClass.simpleName());
-    //        }
-
-    // Write the final DTO class
-    JavaFile.builder(dtoClass.packageName(), dtoBuilder.build())
-        .indent("    ")
-        .build()
-        .writeTo(filer);
-  }
-
-  /**
-   * Returns the appropriate collection implementation type based on the provided collection type.
-   *
-   * @param collectionType the TypeMirror representing the collection type
-   * @return the TypeName of the collection implementation
-   */
-  private static TypeName getCollectionImplType(TypeMirror collectionType) {
-    if (collectionType.toString().startsWith("java.util.List")) {
-      return ClassName.get(ArrayList.class);
-    } else if (collectionType.toString().startsWith("java.util.Set")) {
-      return ClassName.get(HashSet.class);
-    } else if (collectionType.toString().startsWith("java.util.Map")) {
-      return ClassName.get(HashMap.class);
-    }
-    return ClassName.get(Object.class);
-  }
-
-  /**
-   * Adds common methods (toString, equals, hashCode) to the DTO class.
-   *
-   * @param builder      the TypeSpec.Builder for the DTO class
-   * @param fields       the list of fields in the DTO
-   * @param className    the name of the DTO class
-   * @param originalName the original name of the entity class
-   * @throws ClassNotFoundException if the base DTO class cannot be found
-   */
-  private void addCommonMethods(
-      TypeSpec.Builder builder, List<Element> fields, String className, String originalName)
-      throws ClassNotFoundException {
-    ClassName objectsClass = ClassName.get("java.util", "Objects");
-
-    List<String> baseDtoFields = getBaseDtoFields();
-    List<String> allFieldNames = new ArrayList<>();
-
-    // 2. Add entity fields
-    fields.stream().map(f -> f.getSimpleName().toString()).forEach(allFieldNames::add);
-
-    generateCommonMethods(builder, fields, className, objectsClass);
-  }
-
-  /**
-   * Retrieves the field names from the BaseDTO class.
-   *
-   * @return a list of field names in the BaseDTO class
-   * @throws ClassNotFoundException if the BaseDTO class cannot be found in the classpath
-   */
-  private List<String> getBaseDtoFields() throws ClassNotFoundException {
-    List<String> fieldNames = new ArrayList<>();
-
-    // Load BaseDTO class using element utils
-    TypeElement baseDtoType = elementUtils.getTypeElement(DEV_HYPERAPI_RUNTIME_CORE_ENTITY_DTO);
-    if (baseDtoType != null) {
-      for (Element enclosed : elementUtils.getAllMembers(baseDtoType)) {
-        if (enclosed.getKind() == ElementKind.FIELD) {
-          fieldNames.add(enclosed.getSimpleName().toString());
+        if (allFields.isEmpty()) {
+            String warnMessage =
+                    "%s : The class doesn't contain any fields to generate DTO for. "
+                            + "Ensure it has fields annotated with @HyperResource or not ignored by mapping.";
+            warn(entity, warnMessage, entity.getQualifiedName().toString());
         }
-      }
-    } else {
-      throw new ClassNotFoundException("BaseDTO class not found in classpath");
+
+
+        // Add toString(), equals() and hashCode()
+        addCommonMethods(dtoBuilder, allFields, dtoName, entity.getSimpleName().toString());
+
+        // Add builder pattern if needed
+        // FIXME the mapper wont create proper toDto method
+        //        if (generateBuilder) {
+        //        PropertyGenerator.addBuilderSupport(dtoBuilder, allFields, dtoClass.simpleName());
+        //        }
+
+        // Write the final DTO class
+        JavaFile.builder(dtoClass.packageName(), dtoBuilder.build())
+                .indent("    ")
+                .build()
+                .writeTo(filer);
     }
 
-    return fieldNames;
-  }
-
-  /**
-   * Generates common methods (toString, equals, hashCode) for the DTO class.
-   *
-   * @param builder      the TypeSpec.Builder for the DTO class
-   * @param fields       the list of fields in the DTO
-   * @param className    the name of the DTO class
-   * @param objectsClass the ClassName for the Objects utility class
-   */
-  private void generateCommonMethods(
-      TypeSpec.Builder builder, List<Element> fields, String className, ClassName objectsClass) {
-    // Generate toString()
-    if (!fields.isEmpty()) {
-      StringBuilder toStringFormat = new StringBuilder(className + " [");
-      List<Object> toStringArgs = new ArrayList<>();
-      for (int i = 0; i < fields.size(); i++) {
-        String fieldName = fields.get(i).getSimpleName().toString();
-        if (i > 0) {
-          toStringFormat.append(", ");
+    /**
+     * Returns the appropriate collection implementation type based on the provided collection type.
+     *
+     * @param collectionType the TypeMirror representing the collection type
+     * @return the TypeName of the collection implementation
+     */
+    private static TypeName getCollectionImplType(TypeMirror collectionType) {
+        if (collectionType.toString().startsWith("java.util.List")) {
+            return ClassName.get(ArrayList.class);
+        } else if (collectionType.toString().startsWith("java.util.Set")) {
+            return ClassName.get(HashSet.class);
+        } else if (collectionType.toString().startsWith("java.util.Map")) {
+            return ClassName.get(HashMap.class);
         }
-        toStringFormat.append(fieldName).append("=%s");
-        toStringArgs.add(fieldName);
-      }
-      toStringFormat.append("]");
-
-      // Create the format arguments string
-      String formatArgs =
-          toStringArgs.stream().map(Object::toString).collect(Collectors.joining(", "));
-
-      MethodSpec toString =
-          MethodSpec.methodBuilder("toString")
-              .addModifiers(Modifier.PUBLIC)
-              .returns(String.class)
-              .addAnnotation(Override.class)
-              .addStatement("return String.format($S, $L)", toStringFormat.toString(), formatArgs)
-              .build();
-      builder.addMethod(toString);
+        return ClassName.get(Object.class);
     }
 
-    // Generate equals()
-    if (!fields.isEmpty()) {
-      ClassName dtoClassName = ClassName.bestGuess(className);
+    /**
+     * Adds common methods (toString, equals, hashCode) to the DTO class.
+     *
+     * @param builder      the TypeSpec.Builder for the DTO class
+     * @param fields       the list of fields in the DTO
+     * @param className    the name of the DTO class
+     * @param originalName the original name of the entity class
+     * @throws ClassNotFoundException if the base DTO class cannot be found
+     */
+    private void addCommonMethods(
+            TypeSpec.Builder builder, List<Element> fields, String className, String originalName)
+            throws ClassNotFoundException {
+        ClassName objectsClass = ClassName.get("java.util", "Objects");
 
-      MethodSpec.Builder equalsBuilder =
-          MethodSpec.methodBuilder("equals")
-              .addModifiers(Modifier.PUBLIC)
-              .returns(boolean.class)
-              .addAnnotation(Override.class)
-              .addParameter(Object.class, "o")
-              .beginControlFlow("if (this == o)")
-              .addStatement("return true")
-              .endControlFlow()
-              .beginControlFlow("if (o == null || getClass() != o.getClass())")
-              .addStatement("return false")
-              .endControlFlow()
-              .addStatement("$T that = ($T) o", dtoClassName, dtoClassName);
+        List<String> baseDtoFields = getBaseDtoFields();
+        List<String> allFieldNames = new ArrayList<>();
 
-      // Build the equality comparison chain
-      CodeBlock.Builder comparisonBuilder = CodeBlock.builder();
-      for (Element field : fields) {
-        String fieldName = field.getSimpleName().toString();
-        if (comparisonBuilder.isEmpty()) {
-          comparisonBuilder.add("$T.equals(this.$L, that.$L)", objectsClass, fieldName, fieldName);
+        // 2. Add entity fields
+        fields.stream().map(f -> f.getSimpleName().toString()).forEach(allFieldNames::add);
+
+        generateCommonMethods(builder, fields, className, objectsClass);
+    }
+
+    /**
+     * Retrieves the field names from the BaseDTO class.
+     *
+     * @return a list of field names in the BaseDTO class
+     * @throws ClassNotFoundException if the BaseDTO class cannot be found in the classpath
+     */
+    private List<String> getBaseDtoFields() throws ClassNotFoundException {
+        List<String> fieldNames = new ArrayList<>();
+
+        // Load BaseDTO class using element utils
+        TypeElement baseDtoType = elementUtils.getTypeElement(DEV_HYPERAPI_RUNTIME_CORE_ENTITY_DTO);
+        if (baseDtoType != null) {
+            for (Element enclosed : elementUtils.getAllMembers(baseDtoType)) {
+                if (enclosed.getKind() == ElementKind.FIELD) {
+                    fieldNames.add(enclosed.getSimpleName().toString());
+                }
+            }
         } else {
-          comparisonBuilder.add(
-              " &&\n    $T.equals(this.$L, that.$L)", objectsClass, fieldName, fieldName);
-        }
-      }
-
-      equalsBuilder.addStatement("return $L", comparisonBuilder.build());
-      builder.addMethod(equalsBuilder.build());
-    }
-
-    // Generate hashCode()
-    if (!fields.isEmpty()) {
-      String hashFields =
-          fields.stream().map(f -> f.getSimpleName().toString()).collect(Collectors.joining(", "));
-
-      MethodSpec hashCode =
-          MethodSpec.methodBuilder("hashCode")
-              .addModifiers(Modifier.PUBLIC)
-              .returns(int.class)
-              .addAnnotation(Override.class)
-              .addStatement("return $T.hash($L)", objectsClass, hashFields)
-              .build();
-
-      builder.addMethod(hashCode);
-    }
-  }
-
-  /**
-   * Generates the create method override for the service class.
-   *
-   * @param dtoClass         the ClassName of the DTO
-   * @param entityEventClass the ClassName of the EntityEvent
-   * @param customEmitter    indicates if a custom event emitter is used
-   * @return the MethodSpec for the create method override
-   */
-  private MethodSpec generateCreateOverride(
-      ClassName dtoClass, ClassName entityEventClass, boolean customEmitter) {
-
-    String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
-    return MethodSpec.methodBuilder("create")
-        .addAnnotation(Override.class)
-        .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
-        .addModifiers(Modifier.PUBLIC)
-        .returns(dtoClass)
-        .addParameter(dtoClass, "dto")
-        .addStatement("$T result = super.create(dto)", dtoClass)
-        .addStatement(
-            strCustomEmitter + "($T.Type.CREATE, mapper.toEntity(result))", entityEventClass)
-        .addStatement("return result")
-        .build();
-  }
-
-  /**
-   * Generates the update method override for the service class.
-   *
-   * @param dtoClass         the ClassName of the DTO
-   * @param entityEventClass the ClassName of the EntityEvent
-   * @param customEmitter    indicates if a custom event emitter is used
-   * @return the MethodSpec for the update method override
-   */
-  private MethodSpec generateUpdateOverride(
-      ClassName dtoClass, ClassName entityEventClass, boolean customEmitter) {
-    String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
-
-    return MethodSpec.methodBuilder("update")
-        .addAnnotation(Override.class)
-        .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
-        .addModifiers(Modifier.PUBLIC)
-        .returns(dtoClass)
-        .addParameter(dtoClass, "dto")
-        .addStatement("$T result = super.update(dto)", dtoClass)
-        .addStatement(
-            strCustomEmitter + "($T.Type.UPDATE, mapper.toEntity(result))", entityEventClass)
-        .addStatement("return result")
-        .build();
-  }
-
-  /**
-   * Generates the delete method override for the service class.
-   *
-   * @param entityEventClass the ClassName of the EntityEvent
-   * @param customEmitter    indicates if a custom event emitter is used
-   * @return the MethodSpec for the delete method override
-   */
-  private MethodSpec generateDeleteOverride(ClassName entityEventClass, boolean customEmitter) {
-    String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
-
-    return MethodSpec.methodBuilder("delete")
-        .addAnnotation(Override.class)
-        .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
-        .addModifiers(Modifier.PUBLIC)
-        .returns(TypeName.VOID)
-        .addParameter(ParameterSpec.builder(ClassName.get(Long.class), "id").build())
-        .addStatement("super.delete(id)")
-        .addStatement(
-            strCustomEmitter + "($T.Type.DELETE, null)", entityEventClass) // if you don’t re-fetch
-        .build();
-  }
-
-  /**
-   * Generates the patch method override for the service class.
-   *
-   * @param dtoClass         the ClassName of the DTO
-   * @param entityEventClass the ClassName of the EntityEvent
-   * @param customEmitter    indicates if a custom event emitter is used
-   * @return the MethodSpec for the patch method override
-   */
-  private MethodSpec generatePatchOverride(
-      ClassName dtoClass, ClassName entityEventClass, boolean customEmitter) {
-    String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
-
-    return MethodSpec.methodBuilder("patch")
-        .addAnnotation(Override.class)
-        .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
-        .addModifiers(Modifier.PUBLIC)
-        .returns(dtoClass)
-        .addParameter(ParameterSpec.builder(ClassName.get(Long.class), "id").build())
-        .addParameter(
-            ParameterSpec.builder(ClassName.get("jakarta.json", "JsonObject"), "patchJson").build())
-        .addStatement("$T result = super.patch(id, patchJson)", dtoClass)
-        .addStatement(
-            strCustomEmitter + "($T.Type.UPDATE, mapper.toEntity(result))", entityEventClass)
-        .addStatement("return result")
-        .build();
-  }
-
-  /**
-   * Generates the service class for the given entity.
-   *
-   * @param entity        the entity TypeElement
-   * @param dtoName       the name of the DTO to generate
-   * @param hyperResource the HyperResource annotation containing configuration
-   * @throws IOException            if there is an error writing the generated file
-   * @throws ClassNotFoundException if the base entity class cannot be found
-   */
-  private void generateService(TypeElement entity, String dtoName, HyperResource hyperResource)
-      throws IOException, ClassNotFoundException {
-    String entityName = entity.getSimpleName().toString();
-    String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
-    String serviceName = entityName + "Service";
-
-    ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
-    ClassName entityClass = ClassName.get(basePackage, entityName);
-    ClassName mapperClass = ClassName.get(basePackage + ".mapper", entityName + "Mapper");
-
-    Events events = hyperResource.events();
-    boolean fireOnCreate = events.onCreate();
-    boolean fireOnUpdate = events.onUpdate();
-    boolean fireOnDelete = events.onDelete();
-    boolean fireOnPatch = events.onDelete();
-
-    TypeName superType =
-        ParameterizedTypeName.get(
-            ClassName.get("com.eorghe.hyperapi.service", "BaseEntityService"),
-            entityClass,
-            dtoClass,
-            mapperClass);
-
-    MethodSpec.Builder constructor =
-        MethodSpec.constructorBuilder()
-            .addModifiers(Modifier.PUBLIC)
-            .addStatement("super($T.class)", dtoClass);
-
-    TypeSpec.Builder serviceClass =
-        TypeSpec.classBuilder(serviceName)
-            .addModifiers(Modifier.PUBLIC)
-            .addAnnotation(generatedAnnotation())
-            .addAnnotation(ClassName.get("jakarta.enterprise.context", "ApplicationScoped"))
-            .superclass(superType);
-
-    // Define injection for the repository
-    MethodSpec repoGetter = generateInjectRepository(entity, basePackage, entityName, serviceClass,
-        entityClass, hyperResource);
-    serviceClass.addMethod(repoGetter);
-
-    Optional<TypeMirror> emitterMirror = getEmitterTypeMirror(entity);
-
-    if (fireOnCreate) {
-      MethodSpec method =
-          generateCreateOverride(
-              dtoClass,
-              ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
-              emitterMirror.isPresent());
-      serviceClass.addMethod(method);
-    }
-
-    if (fireOnUpdate) {
-      MethodSpec method =
-          generateUpdateOverride(
-              dtoClass,
-              ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
-              emitterMirror.isPresent());
-      serviceClass.addMethod(method);
-    }
-
-    if (fireOnDelete) {
-      MethodSpec method =
-          generateDeleteOverride(
-              ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
-              emitterMirror.isPresent());
-      serviceClass.addMethod(method);
-    }
-
-    if (fireOnPatch) {
-      MethodSpec method =
-          generatePatchOverride(
-              dtoClass,
-              ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
-              emitterMirror.isPresent());
-      serviceClass.addMethod(method);
-    }
-
-    // Inject custom emitter if specified
-    emitterMirror.ifPresent(
-        typeMirror ->
-            serviceClass.addField(
-                FieldSpec.builder(
-                        ParameterizedTypeName.get(typeMirror), "emitter", Modifier.PRIVATE)
-                    .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
-                    .build()));
-
-    serviceClass.addMethod(constructor.build());
-
-    JavaFile.builder(basePackage + ".service", serviceClass.build())
-        .indent("    ")
-        .build()
-        .writeTo(filer);
-  }
-
-  /**
-   * Generates the repository injection method for the service class.
-   *
-   * @param entity        the entity TypeElement
-   * @param basePackage   the base package of the entity
-   * @param entityName    the name of the entity
-   * @param serviceClass  the TypeSpec.Builder for the service class
-   * @param entityClass   the ClassName of the entity
-   * @param hyperResource the HyperResource annotation containing configuration
-   * @return the MethodSpec for the repository getter
-   */
-  private MethodSpec generateInjectRepository(TypeElement entity, String basePackage,
-      String entityName, TypeSpec.Builder serviceClass, ClassName entityClass,
-      HyperResource hyperResource) {
-
-    // Add injected repository field
-    ClassName repositoryClass = ClassName.get(basePackage + "." + hyperResource.repositoryPackage(),
-        entityName + "Repository");
-    serviceClass.addField(FieldSpec.builder(repositoryClass, "repository", Modifier.PRIVATE)
-        .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
-        .build());
-
-    // Add repository override method
-    ParameterizedTypeName repoType = ParameterizedTypeName.get(
-        ClassName.get("io.quarkus.hibernate.orm.panache", "PanacheRepositoryBase"),
-        entityClass,
-        ClassName.get("java.lang", "Long")
-    );
-
-    MethodSpec repoGetter = MethodSpec.methodBuilder("getRepository")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PROTECTED)
-        .returns(repoType)
-        .addStatement("return repository")
-        .build();
-    return repoGetter;
-  }
-
-  /**
-   * Retrieves the emitter type mirror from the HyperResource annotation.
-   *
-   * @param element the TypeElement to inspect for the HyperResource annotation
-   * @return an Optional containing the TypeMirror of the emitter type if found, otherwise empty
-   */
-  private Optional<TypeMirror> getEmitterTypeMirror(TypeElement element) {
-    for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
-      if (!annotation
-          .getAnnotationType()
-          .toString()
-          .equals("annotations.processor.com.eorghe.runtime.core.HyperResource")) {
-        continue;
-      }
-
-      for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
-          annotation.getElementValues().entrySet()) {
-        if (!entry.getKey().getSimpleName().contentEquals("events")) {
-          continue;
+            throw new ClassNotFoundException("BaseDTO class not found in classpath");
         }
 
-        AnnotationMirror events = (AnnotationMirror) entry.getValue().getValue();
-
-        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> ev :
-            events.getElementValues().entrySet()) {
-          if (ev.getKey().getSimpleName().contentEquals("emitter")) {
-            return Optional.of((TypeMirror) ev.getValue().getValue());
-          }
-        }
-      }
+        return fieldNames;
     }
-    return Optional.empty();
-  }
 
-  /**
-   * Generates the controller class for the given entity.
-   *
-   * @param entity        the entity TypeElement
-   * @param dtoName       the name of the DTO to generate
-   * @param hyperResource the HyperResource annotation containing configuration
-   * @throws IOException if there is an error writing the generated file
-   */
-  private void generateController(TypeElement entity, String dtoName, HyperResource hyperResource)
-      throws IOException {
-    String entityName = entity.getSimpleName().toString();
-    String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
-    String controllerName = entityName + "HyperResource";
+    /**
+     * Generates common methods (toString, equals, hashCode) for the DTO class.
+     *
+     * @param builder      the TypeSpec.Builder for the DTO class
+     * @param fields       the list of fields in the DTO
+     * @param className    the name of the DTO class
+     * @param objectsClass the ClassName for the Objects utility class
+     */
+    private void generateCommonMethods(
+            TypeSpec.Builder builder, List<Element> fields, String className, ClassName objectsClass) {
+        // Generate toString()
+        if (!fields.isEmpty()) {
+            StringBuilder toStringFormat = new StringBuilder(className + " [");
+            List<Object> toStringArgs = new ArrayList<>();
+            for (int i = 0; i < fields.size(); i++) {
+                String fieldName = fields.get(i).getSimpleName().toString();
+                if (i > 0) {
+                    toStringFormat.append(", ");
+                }
+                toStringFormat.append(fieldName).append("=%s");
+                toStringArgs.add(fieldName);
+            }
+            toStringFormat.append("]");
 
-    ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
-    ClassName mapperClass = ClassName.get(basePackage + ".mapper", entityName + "Mapper");
-    ClassName serviceClass = ClassName.get(basePackage + ".service", entityName + "Service");
-    ClassName entityClass = ClassName.get(basePackage, entityName);
+            // Create the format arguments string
+            String formatArgs =
+                    toStringArgs.stream().map(Object::toString).collect(Collectors.joining(", "));
 
-    TypeName superType =
-        ParameterizedTypeName.get(
-            ClassName.get("com.eorghe.hyperapi.controller", "RestController"),
-            dtoClass,
-            mapperClass,
-            entityClass);
+            MethodSpec toString =
+                    MethodSpec.methodBuilder("toString")
+                            .addModifiers(Modifier.PUBLIC)
+                            .returns(String.class)
+                            .addAnnotation(Override.class)
+                            .addStatement("return String.format($S, $L)", toStringFormat.toString(), formatArgs)
+                            .build();
+            builder.addMethod(toString);
+        }
 
-    String path =
-        hyperResource.path().isBlank() ? "/api/" + entityName.toLowerCase() : hyperResource.path();
-    Scope scope = hyperResource.scope();
+        // Generate equals()
+        if (!fields.isEmpty()) {
+            ClassName dtoClassName = ClassName.bestGuess(className);
 
-    TypeSpec.Builder ctrl =
-        TypeSpec.classBuilder(controllerName)
-            .addModifiers(Modifier.PUBLIC)
-            .addAnnotation(generatedAnnotation())
-            .addAnnotation(
-                AnnotationSpec.builder(ClassName.get("jakarta.ws.rs", "Path"))
-                    .addMember("value", "$S", path)
-                    .build())
-            .addAnnotation(
-                AnnotationSpec.builder(ClassName.bestGuess(scope.getScopeClass())).build())
-            .superclass(superType)
-            .addField(
-                FieldSpec.builder(serviceClass, "service", Modifier.PRIVATE)
-                    .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
-                    .build())
-            .addMethod( // Overriding getService method
-                MethodSpec.methodBuilder("getService")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC)
-                    .returns(
-                        ParameterizedTypeName.get(
-                            ClassName.get("com.eorghe.hyperapi.service", "BaseEntityService"),
-                            entityClass,
+            MethodSpec.Builder equalsBuilder =
+                    MethodSpec.methodBuilder("equals")
+                            .addModifiers(Modifier.PUBLIC)
+                            .returns(boolean.class)
+                            .addAnnotation(Override.class)
+                            .addParameter(Object.class, "o")
+                            .beginControlFlow("if (this == o)")
+                            .addStatement("return true")
+                            .endControlFlow()
+                            .beginControlFlow("if (o == null || getClass() != o.getClass())")
+                            .addStatement("return false")
+                            .endControlFlow()
+                            .addStatement("$T that = ($T) o", dtoClassName, dtoClassName);
+
+            // Build the equality comparison chain
+            CodeBlock.Builder comparisonBuilder = CodeBlock.builder();
+            for (Element field : fields) {
+                String fieldName = field.getSimpleName().toString();
+                if (comparisonBuilder.isEmpty()) {
+                    comparisonBuilder.add("$T.equals(this.$L, that.$L)", objectsClass, fieldName, fieldName);
+                } else {
+                    comparisonBuilder.add(
+                            " &&\n    $T.equals(this.$L, that.$L)", objectsClass, fieldName, fieldName);
+                }
+            }
+
+            equalsBuilder.addStatement("return $L", comparisonBuilder.build());
+            builder.addMethod(equalsBuilder.build());
+        }
+
+        // Generate hashCode()
+        if (!fields.isEmpty()) {
+            String hashFields =
+                    fields.stream().map(f -> f.getSimpleName().toString()).collect(Collectors.joining(", "));
+
+            MethodSpec hashCode =
+                    MethodSpec.methodBuilder("hashCode")
+                            .addModifiers(Modifier.PUBLIC)
+                            .returns(int.class)
+                            .addAnnotation(Override.class)
+                            .addStatement("return $T.hash($L)", objectsClass, hashFields)
+                            .build();
+
+            builder.addMethod(hashCode);
+        }
+    }
+
+    /**
+     * Generates the create method override for the service class.
+     *
+     * @param dtoClass         the ClassName of the DTO
+     * @param entityEventClass the ClassName of the EntityEvent
+     * @param customEmitter    indicates if a custom event emitter is used
+     * @return the MethodSpec for the create method override
+     */
+    private MethodSpec generateCreateOverride(
+            ClassName dtoClass, ClassName entityEventClass, boolean customEmitter) {
+
+        String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
+        return MethodSpec.methodBuilder("create")
+                .addAnnotation(Override.class)
+                .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
+                .addModifiers(Modifier.PUBLIC)
+                .returns(dtoClass)
+                .addParameter(dtoClass, "dto")
+                .addStatement("$T result = super.create(dto)", dtoClass)
+                .addStatement(
+                        strCustomEmitter + "($T.Type.CREATE, mapper.toEntity(result))", entityEventClass)
+                .addStatement("return result")
+                .build();
+    }
+
+    /**
+     * Generates the update method override for the service class.
+     *
+     * @param dtoClass         the ClassName of the DTO
+     * @param entityEventClass the ClassName of the EntityEvent
+     * @param customEmitter    indicates if a custom event emitter is used
+     * @return the MethodSpec for the update method override
+     */
+    private MethodSpec generateUpdateOverride(
+            ClassName dtoClass, ClassName entityEventClass, boolean customEmitter) {
+        String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
+
+        return MethodSpec.methodBuilder("update")
+                .addAnnotation(Override.class)
+                .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
+                .addModifiers(Modifier.PUBLIC)
+                .returns(dtoClass)
+                .addParameter(dtoClass, "dto")
+                .addStatement("$T result = super.update(dto)", dtoClass)
+                .addStatement(
+                        strCustomEmitter + "($T.Type.UPDATE, mapper.toEntity(result))", entityEventClass)
+                .addStatement("return result")
+                .build();
+    }
+
+    /**
+     * Generates the delete method override for the service class.
+     *
+     * @param entityEventClass the ClassName of the EntityEvent
+     * @param customEmitter    indicates if a custom event emitter is used
+     * @return the MethodSpec for the delete method override
+     */
+    private MethodSpec generateDeleteOverride(ClassName entityEventClass, boolean customEmitter) {
+        String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
+
+        return MethodSpec.methodBuilder("delete")
+                .addAnnotation(Override.class)
+                .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeName.VOID)
+                .addParameter(ParameterSpec.builder(ClassName.get(Long.class), "id").build())
+                .addStatement("super.delete(id)")
+                .addStatement(
+                        strCustomEmitter + "($T.Type.DELETE, null)", entityEventClass) // if you don’t re-fetch
+                .build();
+    }
+
+    /**
+     * Generates the patch method override for the service class.
+     *
+     * @param dtoClass         the ClassName of the DTO
+     * @param entityEventClass the ClassName of the EntityEvent
+     * @param customEmitter    indicates if a custom event emitter is used
+     * @return the MethodSpec for the patch method override
+     */
+    private MethodSpec generatePatchOverride(
+            ClassName dtoClass, ClassName entityEventClass, boolean customEmitter) {
+        String strCustomEmitter = customEmitter ? "emitter.emit" : "fireEvent";
+
+        return MethodSpec.methodBuilder("patch")
+                .addAnnotation(Override.class)
+                .addAnnotation(ClassName.get("jakarta.transaction", "Transactional"))
+                .addModifiers(Modifier.PUBLIC)
+                .returns(dtoClass)
+                .addParameter(ParameterSpec.builder(ClassName.get(Long.class), "id").build())
+                .addParameter(
+                        ParameterSpec.builder(ClassName.get("jakarta.json", "JsonObject"), "patchJson").build())
+                .addStatement("$T result = super.patch(id, patchJson)", dtoClass)
+                .addStatement(
+                        strCustomEmitter + "($T.Type.UPDATE, mapper.toEntity(result))", entityEventClass)
+                .addStatement("return result")
+                .build();
+    }
+
+    /**
+     * Generates the service class for the given entity.
+     *
+     * @param entity        the entity TypeElement
+     * @param dtoName       the name of the DTO to generate
+     * @param hyperResource the HyperResource annotation containing configuration
+     * @throws IOException            if there is an error writing the generated file
+     * @throws ClassNotFoundException if the base entity class cannot be found
+     */
+    private void generateService(TypeElement entity, String dtoName, HyperResource hyperResource)
+            throws IOException, ClassNotFoundException {
+        String entityName = entity.getSimpleName().toString();
+        String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
+        String serviceName = entityName + "Service";
+
+        ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
+        ClassName entityClass = ClassName.get(basePackage, entityName);
+        ClassName mapperClass = ClassName.get(basePackage + ".mapper", entityName + "Mapper");
+
+        Events events = hyperResource.events();
+        boolean fireOnCreate = events.onCreate();
+        boolean fireOnUpdate = events.onUpdate();
+        boolean fireOnDelete = events.onDelete();
+        boolean fireOnPatch = events.onDelete();
+
+        TypeName superType =
+                ParameterizedTypeName.get(
+                        ClassName.get("com.eorghe.hyperapi.service", "BaseEntityService"),
+                        entityClass,
+                        dtoClass,
+                        mapperClass);
+
+        MethodSpec.Builder constructor =
+                MethodSpec.constructorBuilder()
+                        .addModifiers(Modifier.PUBLIC)
+                        .addStatement("super($T.class)", dtoClass);
+
+        TypeSpec.Builder serviceClass =
+                TypeSpec.classBuilder(serviceName)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addAnnotation(generatedAnnotation())
+                        .addAnnotation(ClassName.get("jakarta.enterprise.context", "ApplicationScoped"))
+                        .superclass(superType);
+
+        // Define injection for the repository
+        MethodSpec repoGetter = generateInjectRepository(entity, basePackage, entityName, serviceClass,
+                entityClass, hyperResource);
+        serviceClass.addMethod(repoGetter);
+
+        Optional<TypeMirror> emitterMirror = getEmitterTypeMirror(entity);
+
+        if (fireOnCreate) {
+            MethodSpec method =
+                    generateCreateOverride(
                             dtoClass,
-                            mapperClass))
-                    .addStatement("return service")
-                    .build());
-
-    // Define paging for GetAll method
-    Optional<HttpMethod> isGetMethodDisabled =
-        Arrays.stream(hyperResource.disabledFor())
-            .filter(
-                r -> {
-                  return r == HttpMethod.GET;
-                })
-            .findFirst();
-
-    if (hyperResource.pageable() != null && isGetMethodDisabled.isEmpty()) {
-      int defaultLimit = hyperResource.pageable().limit();
-      int maxLimit = hyperResource.pageable().maxLimit();
-
-      MethodSpec getAll =
-          MethodSpec.methodBuilder("getAll")
-              .addAnnotation(GET.class)
-              .addModifiers(Modifier.PUBLIC)
-              .returns(ParameterizedTypeName.get(ClassName.get("java.util", "List"), dtoClass))
-              .addParameter(
-                  ParameterSpec.builder(TypeName.INT, "offset")
-                      .addAnnotation(
-                          AnnotationSpec.builder(QueryParam.class)
-                              .addMember("value", "$S", "offset")
-                              .build())
-                      .addAnnotation(
-                          AnnotationSpec.builder(DefaultValue.class)
-                              .addMember("value", "$S", "0")
-                              .build())
-                      .build())
-              .addParameter(
-                  ParameterSpec.builder(TypeName.INT, "limit")
-                      .addAnnotation(
-                          AnnotationSpec.builder(QueryParam.class)
-                              .addMember("value", "$S", "limit")
-                              .build())
-                      .addAnnotation(
-                          AnnotationSpec.builder(DefaultValue.class)
-                              .addMember("value", "$S", String.valueOf(defaultLimit))
-                              .build())
-                      .build())
-              .addStatement("return getService().findAll(offset, Math.min(limit, $L))", maxLimit)
-              .build();
-
-      ctrl.addMethod(getAll);
-    }
-
-    // Disabled user-defined endpoints
-    if (hyperResource.disabledFor().length > 0) {
-
-      Set<String> disabledMethods =
-          Arrays.stream(hyperResource.disabledFor())
-              .map(HttpMethod::name)
-              .collect(Collectors.toSet());
-
-      disabledMethods.forEach(
-          method -> {
-            if (method.equals("DELETE")) {
-              ctrl.addMethod(generateDisabledDeleteMethod(dtoClass));
-            }
-            if (method.equals("GET")) {
-              ctrl.addMethod(generateDisabledGetByIdMethod(dtoClass));
-              ctrl.addMethod(generateDisabledGetAllMethod(dtoClass));
-            }
-            if (method.equals("POST")) {
-              ctrl.addMethod(generateDisabledPostMethod(dtoClass));
-            }
-            if (method.equals("PUT")) {
-              ctrl.addMethod(generateDisabledPutMethod(dtoClass));
-            }
-            if (method.equals("PATCH")) {
-              ctrl.addMethod(generateDisabledPatchMethod());
-            }
-          });
-    }
-
-    JavaFile.builder(basePackage + ".controller", ctrl.build())
-        .indent("    ")
-        .build()
-        .writeTo(filer);
-  }
-
-  /**
-   * Generates a disabled delete method for the controller.
-   *
-   * @param dtoClass the ClassName of the DTO
-   * @return the MethodSpec for the disabled delete method
-   */
-  private MethodSpec generateDisabledDeleteMethod(ClassName dtoClass) {
-    return MethodSpec.methodBuilder("delete")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PUBLIC)
-        .addParameter(ParameterSpec.builder(Object.class, "id").build())
-        .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
-        .addStatement(
-            "throw new $T($S)",
-            ClassName.get("jakarta.ws.rs", "NotFoundException"),
-            "DELETE method is disabled for this resource")
-        .build();
-  }
-
-  /**
-   * Generates a disabled getAll method for the controller.
-   *
-   * @param dtoClass the ClassName of the DTO
-   * @return the MethodSpec for the disabled getAll method
-   */
-  private MethodSpec generateDisabledGetAllMethod(ClassName dtoClass) {
-    return MethodSpec.methodBuilder("getAll")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PUBLIC)
-        .returns(ParameterizedTypeName.get(ClassName.get("java.util", "List"), dtoClass))
-        .addParameter(ParameterSpec.builder(TypeName.INT, "offset").build())
-        .addParameter(ParameterSpec.builder(TypeName.INT, "limit").build())
-        .addStatement(
-            "throw new $T($S)",
-            ClassName.get("jakarta.ws.rs", "NotFoundException"),
-            "Get All method is disabled for this resource")
-        .build();
-  }
-
-  /**
-   * Generates a disabled getById method for the controller.
-   *
-   * @param dtoClass the ClassName of the DTO
-   * @return the MethodSpec for the disabled getById method
-   */
-  private MethodSpec generateDisabledGetByIdMethod(ClassName dtoClass) {
-    return MethodSpec.methodBuilder("getById")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PUBLIC)
-        .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
-        .addParameter(ParameterSpec.builder(Long.class, "id").build())
-        .addStatement(
-            "throw new $T($S)",
-            ClassName.get("jakarta.ws.rs", "NotFoundException"),
-            "Get By Id method is disabled for this resource")
-        .build();
-  }
-
-  /**
-   * Generates a disabled post method for the controller.
-   *
-   * @param dtoClass the ClassName of the DTO
-   * @return the MethodSpec for the disabled post method
-   */
-  private MethodSpec generateDisabledPostMethod(ClassName dtoClass) {
-    return MethodSpec.methodBuilder("create")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PUBLIC)
-        .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
-        .addParameter(dtoClass, "dto")
-        .addStatement(
-            "throw new $T($S)",
-            ClassName.get("jakarta.ws.rs", "NotFoundException"),
-            "POST method is disabled for this resource")
-        .build();
-  }
-
-  /**
-   * Generates a disabled put method for the controller.
-   *
-   * @param dtoClass the ClassName of the DTO
-   * @return the MethodSpec for the disabled put method
-   */
-  private MethodSpec generateDisabledPutMethod(ClassName dtoClass) {
-    return MethodSpec.methodBuilder("update")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PUBLIC)
-        .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
-        .addParameter(ParameterSpec.builder(Object.class, "id").build())
-        .addParameter(dtoClass, "dto")
-        .addStatement(
-            "throw new $T($S)",
-            ClassName.get("jakarta.ws.rs", "NotFoundException"),
-            "PUT method is disabled for this resource")
-        .build();
-  }
-
-  /**
-   * Generates a disabled patch method for the controller.
-   *
-   * @return the MethodSpec for the disabled patch method
-   */
-  private MethodSpec generateDisabledPatchMethod() {
-    return MethodSpec.methodBuilder("patch")
-        .addAnnotation(Override.class)
-        .addModifiers(Modifier.PUBLIC)
-        .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
-        .addParameter(ParameterSpec.builder(Object.class, "id").build())
-        .addParameter(ClassName.get("jakarta.json", "JsonObject"), "patchJson")
-        .addStatement(
-            "throw new $T($S)",
-            ClassName.get("jakarta.ws.rs", "NotFoundException"),
-            "PATH method is disabled for this resource")
-        .build();
-  }
-
-  /**
-   * Logs an error message with the specified element and message.
-   *
-   * @param e   the Element to log the error for
-   * @param msg the error message to log
-   */
-  private void error(Element e, String msg) {
-    messager.printMessage(Diagnostic.Kind.ERROR, msg, e);
-  }
-
-  /**
-   * Logs an error message with the specified element, message, and arguments.
-   *
-   * @param e    the Element to log the error for
-   * @param msg  the error message to log, formatted with String.format
-   * @param args the arguments to format the message with
-   */
-  private void error(Element e, String msg, String... args) {
-    messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
-  }
-
-  /**
-   * Logs an informational message with the specified element and message.
-   *
-   * @param e   the Element to log the info for
-   * @param msg the informational message to log
-   */
-  private void info(Element e, String msg) {
-    messager.printMessage(Diagnostic.Kind.NOTE, msg, e);
-  }
-
-  /**
-   * Logs a warning message with the specified element and message.
-   *
-   * @param e   the Element to log the warning for
-   * @param msg the warning message to log
-   */
-  private void warn(Element e, String msg) {
-    messager.printMessage(Diagnostic.Kind.NOTE, msg, e);
-  }
-
-  /**
-   * Logs a warning message with the specified element, message, and arguments.
-   *
-   * @param e    the Element to log the warning for
-   * @param msg  the warning message to log, formatted with String.format
-   * @param args the arguments to format the message with
-   */
-  private void warn(Element e, String msg, String... args) {
-    messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args), e);
-  }
-
-  /**
-   * Sanitizes the DTO name based on the entity name and raw DTO name.
-   *
-   * @param entityName the name of the entity
-   * @param rawDto     the raw DTO name provided by the user
-   * @return
-   */
-  private String sanitizeDtoName(String entityName, String rawDto) {
-    if (rawDto == null || rawDto.isBlank()) {
-      return entityName + "DTO";
-    }
-    String cleaned = rawDto.replaceAll("(?i)_?dto$", "").trim();
-    return cleaned + "DTO";
-  }
-
-  /**
-   * Generates @Generated annotation with detailed build metadata
-   */
-  private AnnotationSpec generatedAnnotation() {
-    return AnnotationSpec.builder(Generated.class)
-        .addMember("value", "$S", "com.eorghe.hyperapi.processor.HyperResourceProcessor")
-        .addMember(
-            "date", "$S", OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
-        .addMember(
-            "comments",
-            "$S",
-            String.format(
-                "Source version: %s\n"
-                    + "Compiler: %s %s\n"
-                    + "Build environment: %s %s (%s)\n"
-                    + "Project: %s\n"
-                    + "License: Apache 2.0",
-                Runtime.version(),
-                System.getProperty("java.vm.name"),
-                System.getProperty("java.vm.version"),
-                System.getProperty("os.name"),
-                System.getProperty("os.version"),
-                System.getProperty("os.arch"),
-                "HyperAPI Quarkus Extension"))
-        .build();
-  }
-
-  /**
-   * Converts entity field types to their corresponding DTO types.
-   *
-   * @param fieldType the original field type from the entity
-   * @param basePackage the base package of the current entity
-   * @return the converted TypeName (DTO type if applicable, original type otherwise)
-   */
-  private TypeName convertEntityTypeToDto(TypeMirror fieldType, String basePackage) {
-    // Handle collection types
-    if (PropertyGenerator.isCollectionType(fieldType)) {
-      return handleCollectionTypeConversion(fieldType, basePackage);
-    }
-
-    // Handle single custom entity types
-    if (PropertyGenerator.isCustomObject(fieldType)) {
-      String typeName = fieldType.toString();
-
-      // Check if it's an entity in the same package that might have a DTO
-      if (typeName.startsWith(basePackage) && !typeName.contains(".dto.")) {
-        String entityName = typeName.substring(typeName.lastIndexOf('.') + 1);
-
-        // Check if this entity has @HyperResource annotation
-        TypeElement entityElement = elementUtils.getTypeElement(typeName);
-        if (entityElement != null && entityElement.getAnnotation(HyperResource.class) != null) {
-          HyperResource hyperResource = entityElement.getAnnotation(HyperResource.class);
-          String dtoName = sanitizeDtoName(entityName, hyperResource.dto());
-          return ClassName.get(basePackage + ".dto", dtoName);
+                            ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
+                            emitterMirror.isPresent());
+            serviceClass.addMethod(method);
         }
-      }
+
+        if (fireOnUpdate) {
+            MethodSpec method =
+                    generateUpdateOverride(
+                            dtoClass,
+                            ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
+                            emitterMirror.isPresent());
+            serviceClass.addMethod(method);
+        }
+
+        if (fireOnDelete) {
+            MethodSpec method =
+                    generateDeleteOverride(
+                            ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
+                            emitterMirror.isPresent());
+            serviceClass.addMethod(method);
+        }
+
+        if (fireOnPatch) {
+            MethodSpec method =
+                    generatePatchOverride(
+                            dtoClass,
+                            ClassName.get("com.eorghe.hyperapi.events", "EntityEvent"),
+                            emitterMirror.isPresent());
+            serviceClass.addMethod(method);
+        }
+
+        // Inject custom emitter if specified
+        emitterMirror.ifPresent(
+                typeMirror ->
+                        serviceClass.addField(
+                                FieldSpec.builder(
+                                                ParameterizedTypeName.get(typeMirror), "emitter", Modifier.PRIVATE)
+                                        .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
+                                        .build()));
+
+        serviceClass.addMethod(constructor.build());
+
+        JavaFile.builder(basePackage + ".service", serviceClass.build())
+                .indent("    ")
+                .build()
+                .writeTo(filer);
     }
 
-    return TypeName.get(fieldType);
-  }
+    /**
+     * Generates the repository injection method for the service class.
+     *
+     * @param entity        the entity TypeElement
+     * @param basePackage   the base package of the entity
+     * @param entityName    the name of the entity
+     * @param serviceClass  the TypeSpec.Builder for the service class
+     * @param entityClass   the ClassName of the entity
+     * @param hyperResource the HyperResource annotation containing configuration
+     * @return the MethodSpec for the repository getter
+     */
+    private MethodSpec generateInjectRepository(TypeElement entity, String basePackage,
+                                                String entityName, TypeSpec.Builder serviceClass, ClassName entityClass,
+                                                HyperResource hyperResource) {
 
-  /**
-   * Handles conversion for collection types (List, Set, Map).
-   *
-   * @param collectionType the collection type to convert
-   * @param basePackage the base package of the current entity
-   * @return the converted collection TypeName with DTO element types
-   */
-  private TypeName handleCollectionTypeConversion(TypeMirror collectionType, String basePackage) {
-    if (!(collectionType instanceof DeclaredType)) {
-      return TypeName.get(collectionType);
+        // Add injected repository field
+        ClassName repositoryClass = ClassName.get(basePackage + "." + hyperResource.repositoryPackage(),
+                entityName + "Repository");
+        serviceClass.addField(FieldSpec.builder(repositoryClass, "repository", Modifier.PRIVATE)
+                .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
+                .build());
+
+        // Add repository override method
+        ParameterizedTypeName repoType = ParameterizedTypeName.get(
+                ClassName.get("io.quarkus.hibernate.orm.panache", "PanacheRepositoryBase"),
+                entityClass,
+                ClassName.get("java.lang", "Long")
+        );
+
+        MethodSpec repoGetter = MethodSpec.methodBuilder("getRepository")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PROTECTED)
+                .returns(repoType)
+                .addStatement("return repository")
+                .build();
+        return repoGetter;
     }
 
-    DeclaredType declaredType = (DeclaredType) collectionType;
-    List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+    /**
+     * Retrieves the emitter type mirror from the HyperResource annotation.
+     *
+     * @param element the TypeElement to inspect for the HyperResource annotation
+     * @return an Optional containing the TypeMirror of the emitter type if found, otherwise empty
+     */
+    private Optional<TypeMirror> getEmitterTypeMirror(TypeElement element) {
+        for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
+            if (!annotation
+                    .getAnnotationType()
+                    .toString()
+                    .equals("annotations.processor.com.eorghe.runtime.core.HyperResource")) {
+                continue;
+            }
 
-    if (typeArgs.isEmpty()) {
-      return TypeName.get(collectionType);
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
+                    annotation.getElementValues().entrySet()) {
+                if (!entry.getKey().getSimpleName().contentEquals("events")) {
+                    continue;
+                }
+
+                AnnotationMirror events = (AnnotationMirror) entry.getValue().getValue();
+
+                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> ev :
+                        events.getElementValues().entrySet()) {
+                    if (ev.getKey().getSimpleName().contentEquals("emitter")) {
+                        return Optional.of((TypeMirror) ev.getValue().getValue());
+                    }
+                }
+            }
+        }
+        return Optional.empty();
     }
 
-    String rawTypeName = collectionType.toString();
+    /**
+     * Generates the controller class for the given entity.
+     *
+     * @param entity        the entity TypeElement
+     * @param dtoName       the name of the DTO to generate
+     * @param hyperResource the HyperResource annotation containing configuration
+     * @throws IOException if there is an error writing the generated file
+     */
+    private void generateController(TypeElement entity, String dtoName, HyperResource hyperResource)
+            throws IOException {
+        String entityName = entity.getSimpleName().toString();
+        String basePackage = elementUtils.getPackageOf(entity).getQualifiedName().toString();
+        String controllerName = entityName + "HyperResource";
 
-    if (rawTypeName.startsWith("java.util.List")) {
-      TypeName elementType = convertEntityTypeToDto(typeArgs.get(0), basePackage);
-      return ParameterizedTypeName.get(ClassName.get("java.util", "List"), elementType);
-    } else if (rawTypeName.startsWith("java.util.Set")) {
-      TypeName elementType = convertEntityTypeToDto(typeArgs.get(0), basePackage);
-      return ParameterizedTypeName.get(ClassName.get("java.util", "Set"), elementType);
-    } else if (rawTypeName.startsWith("java.util.Map")) {
-      TypeName keyType = convertEntityTypeToDto(typeArgs.get(0), basePackage);
-      TypeName valueType = typeArgs.size() > 1 ? convertEntityTypeToDto(typeArgs.get(1), basePackage) : TypeName.get(Object.class);
-      return ParameterizedTypeName.get(ClassName.get("java.util", "Map"), keyType, valueType);
+        ClassName dtoClass = ClassName.get(basePackage + ".dto", dtoName);
+        ClassName mapperClass = ClassName.get(basePackage + ".mapper", entityName + "Mapper");
+        ClassName serviceClass = ClassName.get(basePackage + ".service", entityName + "Service");
+        ClassName entityClass = ClassName.get(basePackage, entityName);
+
+        TypeName superType =
+                ParameterizedTypeName.get(
+                        ClassName.get("com.eorghe.hyperapi.controller", "RestController"),
+                        dtoClass,
+                        mapperClass,
+                        entityClass);
+
+        String path =
+                hyperResource.path().isBlank() ? "/api/" + entityName.toLowerCase() : hyperResource.path();
+        Scope scope = hyperResource.scope();
+
+        TypeSpec.Builder ctrl =
+                TypeSpec.classBuilder(controllerName)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addAnnotation(generatedAnnotation())
+                        .addAnnotation(
+                                AnnotationSpec.builder(ClassName.get("jakarta.ws.rs", "Path"))
+                                        .addMember("value", "$S", path)
+                                        .build())
+                        .addAnnotation(
+                                AnnotationSpec.builder(ClassName.bestGuess(scope.getScopeClass())).build())
+                        .superclass(superType)
+                        .addField(
+                                FieldSpec.builder(serviceClass, "service", Modifier.PRIVATE)
+                                        .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
+                                        .build())
+                        .addMethod( // Overriding getService method
+                                MethodSpec.methodBuilder("getService")
+                                        .addAnnotation(Override.class)
+                                        .addModifiers(Modifier.PUBLIC)
+                                        .returns(
+                                                ParameterizedTypeName.get(
+                                                        ClassName.get("com.eorghe.hyperapi.service", "BaseEntityService"),
+                                                        entityClass,
+                                                        dtoClass,
+                                                        mapperClass))
+                                        .addStatement("return service")
+                                        .build());
+
+        // Define paging for GetAll method
+        Optional<HttpMethod> isGetMethodDisabled =
+                Arrays.stream(hyperResource.disabledFor())
+                        .filter(
+                                r -> {
+                                    return r == HttpMethod.GET;
+                                })
+                        .findFirst();
+
+        if (hyperResource.pageable() != null && isGetMethodDisabled.isEmpty()) {
+            int defaultLimit = hyperResource.pageable().limit();
+            int maxLimit = hyperResource.pageable().maxLimit();
+
+            MethodSpec getAll =
+                    MethodSpec.methodBuilder("getAll")
+                            .addAnnotation(GET.class)
+                            .addModifiers(Modifier.PUBLIC)
+                            .returns(ParameterizedTypeName.get(ClassName.get("java.util", "List"), dtoClass))
+                            .addParameter(
+                                    ParameterSpec.builder(TypeName.INT, "offset")
+                                            .addAnnotation(
+                                                    AnnotationSpec.builder(QueryParam.class)
+                                                            .addMember("value", "$S", "offset")
+                                                            .build())
+                                            .addAnnotation(
+                                                    AnnotationSpec.builder(DefaultValue.class)
+                                                            .addMember("value", "$S", "0")
+                                                            .build())
+                                            .build())
+                            .addParameter(
+                                    ParameterSpec.builder(TypeName.INT, "limit")
+                                            .addAnnotation(
+                                                    AnnotationSpec.builder(QueryParam.class)
+                                                            .addMember("value", "$S", "limit")
+                                                            .build())
+                                            .addAnnotation(
+                                                    AnnotationSpec.builder(DefaultValue.class)
+                                                            .addMember("value", "$S", String.valueOf(defaultLimit))
+                                                            .build())
+                                            .build())
+                            .addStatement("return getService().findAll(offset, Math.min(limit, $L))", maxLimit)
+                            .build();
+
+            ctrl.addMethod(getAll);
+        }
+
+        // Disabled user-defined endpoints
+        if (hyperResource.disabledFor().length > 0) {
+
+            Set<String> disabledMethods =
+                    Arrays.stream(hyperResource.disabledFor())
+                            .map(HttpMethod::name)
+                            .collect(Collectors.toSet());
+
+            disabledMethods.forEach(
+                    method -> {
+                        if (method.equals("DELETE")) {
+                            ctrl.addMethod(generateDisabledDeleteMethod(dtoClass));
+                        }
+                        if (method.equals("GET")) {
+                            ctrl.addMethod(generateDisabledGetByIdMethod(dtoClass));
+                            ctrl.addMethod(generateDisabledGetAllMethod(dtoClass));
+                        }
+                        if (method.equals("POST")) {
+                            ctrl.addMethod(generateDisabledPostMethod(dtoClass));
+                        }
+                        if (method.equals("PUT")) {
+                            ctrl.addMethod(generateDisabledPutMethod(dtoClass));
+                        }
+                        if (method.equals("PATCH")) {
+                            ctrl.addMethod(generateDisabledPatchMethod());
+                        }
+                    });
+        }
+
+        JavaFile.builder(basePackage + ".controller", ctrl.build())
+                .indent("    ")
+                .build()
+                .writeTo(filer);
     }
 
-    return TypeName.get(collectionType);
-  }
+    /**
+     * Generates a disabled delete method for the controller.
+     *
+     * @param dtoClass the ClassName of the DTO
+     * @return the MethodSpec for the disabled delete method
+     */
+    private MethodSpec generateDisabledDeleteMethod(ClassName dtoClass) {
+        return MethodSpec.methodBuilder("delete")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(ParameterSpec.builder(Object.class, "id").build())
+                .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
+                .addStatement(
+                        "throw new $T($S)",
+                        ClassName.get("jakarta.ws.rs", "NotFoundException"),
+                        "DELETE method is disabled for this resource")
+                .build();
+    }
+
+    /**
+     * Generates a disabled getAll method for the controller.
+     *
+     * @param dtoClass the ClassName of the DTO
+     * @return the MethodSpec for the disabled getAll method
+     */
+    private MethodSpec generateDisabledGetAllMethod(ClassName dtoClass) {
+        return MethodSpec.methodBuilder("getAll")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get("java.util", "List"), dtoClass))
+                .addParameter(ParameterSpec.builder(TypeName.INT, "offset").build())
+                .addParameter(ParameterSpec.builder(TypeName.INT, "limit").build())
+                .addStatement(
+                        "throw new $T($S)",
+                        ClassName.get("jakarta.ws.rs", "NotFoundException"),
+                        "Get All method is disabled for this resource")
+                .build();
+    }
+
+    /**
+     * Generates a disabled getById method for the controller.
+     *
+     * @param dtoClass the ClassName of the DTO
+     * @return the MethodSpec for the disabled getById method
+     */
+    private MethodSpec generateDisabledGetByIdMethod(ClassName dtoClass) {
+        return MethodSpec.methodBuilder("getById")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
+                .addParameter(ParameterSpec.builder(Long.class, "id").build())
+                .addStatement(
+                        "throw new $T($S)",
+                        ClassName.get("jakarta.ws.rs", "NotFoundException"),
+                        "Get By Id method is disabled for this resource")
+                .build();
+    }
+
+    /**
+     * Generates a disabled post method for the controller.
+     *
+     * @param dtoClass the ClassName of the DTO
+     * @return the MethodSpec for the disabled post method
+     */
+    private MethodSpec generateDisabledPostMethod(ClassName dtoClass) {
+        return MethodSpec.methodBuilder("create")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
+                .addParameter(dtoClass, "dto")
+                .addStatement(
+                        "throw new $T($S)",
+                        ClassName.get("jakarta.ws.rs", "NotFoundException"),
+                        "POST method is disabled for this resource")
+                .build();
+    }
+
+    /**
+     * Generates a disabled put method for the controller.
+     *
+     * @param dtoClass the ClassName of the DTO
+     * @return the MethodSpec for the disabled put method
+     */
+    private MethodSpec generateDisabledPutMethod(ClassName dtoClass) {
+        return MethodSpec.methodBuilder("update")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
+                .addParameter(ParameterSpec.builder(Object.class, "id").build())
+                .addParameter(dtoClass, "dto")
+                .addStatement(
+                        "throw new $T($S)",
+                        ClassName.get("jakarta.ws.rs", "NotFoundException"),
+                        "PUT method is disabled for this resource")
+                .build();
+    }
+
+    /**
+     * Generates a disabled patch method for the controller.
+     *
+     * @return the MethodSpec for the disabled patch method
+     */
+    private MethodSpec generateDisabledPatchMethod() {
+        return MethodSpec.methodBuilder("patch")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ClassName.get("jakarta.ws.rs.core", "Response"))
+                .addParameter(ParameterSpec.builder(Object.class, "id").build())
+                .addParameter(ClassName.get("jakarta.json", "JsonObject"), "patchJson")
+                .addStatement(
+                        "throw new $T($S)",
+                        ClassName.get("jakarta.ws.rs", "NotFoundException"),
+                        "PATH method is disabled for this resource")
+                .build();
+    }
+
+    /**
+     * Logs an error message with the specified element and message.
+     *
+     * @param e   the Element to log the error for
+     * @param msg the error message to log
+     */
+    private void error(Element e, String msg) {
+        messager.printMessage(Diagnostic.Kind.ERROR, msg, e);
+    }
+
+    /**
+     * Logs an error message with the specified element, message, and arguments.
+     *
+     * @param e    the Element to log the error for
+     * @param msg  the error message to log, formatted with String.format
+     * @param args the arguments to format the message with
+     */
+    private void error(Element e, String msg, String... args) {
+        messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
+    }
+
+    /**
+     * Logs an informational message with the specified element and message.
+     *
+     * @param e   the Element to log the info for
+     * @param msg the informational message to log
+     */
+    private void info(Element e, String msg) {
+        messager.printMessage(Diagnostic.Kind.NOTE, msg, e);
+    }
+
+    /**
+     * Logs a warning message with the specified element and message.
+     *
+     * @param e   the Element to log the warning for
+     * @param msg the warning message to log
+     */
+    private void warn(Element e, String msg) {
+        messager.printMessage(Diagnostic.Kind.NOTE, msg, e);
+    }
+
+    /**
+     * Logs a warning message with the specified element, message, and arguments.
+     *
+     * @param e    the Element to log the warning for
+     * @param msg  the warning message to log, formatted with String.format
+     * @param args the arguments to format the message with
+     */
+    private void warn(Element e, String msg, String... args) {
+        messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args), e);
+    }
+
+    /**
+     * Sanitizes the DTO name based on the entity name and raw DTO name.
+     *
+     * @param entityName the name of the entity
+     * @param rawDto     the raw DTO name provided by the user
+     * @return
+     */
+    private String sanitizeDtoName(String entityName, String rawDto) {
+        if (rawDto == null || rawDto.isBlank()) {
+            return entityName + "DTO";
+        }
+        String cleaned = rawDto.replaceAll("(?i)_?dto$", "").trim();
+        return cleaned + "DTO";
+    }
+
+    /**
+     * Generates @Generated annotation with detailed build metadata
+     */
+    private AnnotationSpec generatedAnnotation() {
+        return AnnotationSpec.builder(Generated.class)
+                .addMember("value", "$S", "com.eorghe.hyperapi.processor.HyperResourceProcessor")
+                .addMember(
+                        "date", "$S", OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+                .addMember(
+                        "comments",
+                        "$S",
+                        String.format(
+                                "Source version: %s\n"
+                                        + "Compiler: %s %s\n"
+                                        + "Build environment: %s %s (%s)\n"
+                                        + "Project: %s\n"
+                                        + "License: Apache 2.0",
+                                Runtime.version(),
+                                System.getProperty("java.vm.name"),
+                                System.getProperty("java.vm.version"),
+                                System.getProperty("os.name"),
+                                System.getProperty("os.version"),
+                                System.getProperty("os.arch"),
+                                "HyperAPI Quarkus Extension"))
+                .build();
+    }
+
+    /**
+     * Converts entity field types to their corresponding DTO types.
+     *
+     * @param fieldType   the original field type from the entity
+     * @param basePackage the base package of the current entity
+     * @return the converted TypeName (DTO type if applicable, original type otherwise)
+     */
+    private TypeName convertEntityTypeToDto(TypeMirror fieldType, String basePackage) {
+        // Handle collection types
+        if (PropertyGenerator.isCollectionType(fieldType)) {
+            return handleCollectionTypeConversion(fieldType, basePackage);
+        }
+
+        // Handle single custom entity types
+        if (PropertyGenerator.isCustomObject(fieldType)) {
+            String typeName = fieldType.toString();
+
+            // Check if it's an entity in the same package that might have a DTO
+            if (typeName.startsWith(basePackage) && !typeName.contains(".dto.")) {
+                String entityName = typeName.substring(typeName.lastIndexOf('.') + 1);
+
+                // Check if this entity has @HyperResource annotation
+                TypeElement entityElement = elementUtils.getTypeElement(typeName);
+                if (entityElement != null && entityElement.getAnnotation(HyperResource.class) != null) {
+                    HyperResource hyperResource = entityElement.getAnnotation(HyperResource.class);
+                    String dtoName = sanitizeDtoName(entityName, hyperResource.dto());
+                    return ClassName.get(basePackage + ".dto", dtoName);
+                }
+            }
+        }
+
+        return TypeName.get(fieldType);
+    }
+
+    /**
+     * Handles conversion for collection types (List, Set, Map).
+     *
+     * @param collectionType the collection type to convert
+     * @param basePackage    the base package of the current entity
+     * @return the converted collection TypeName with DTO element types
+     */
+    private TypeName handleCollectionTypeConversion(TypeMirror collectionType, String basePackage) {
+        if (!(collectionType instanceof DeclaredType)) {
+            return TypeName.get(collectionType);
+        }
+
+        DeclaredType declaredType = (DeclaredType) collectionType;
+        List<? extends TypeMirror> typeArgs = declaredType.getTypeArguments();
+
+        if (typeArgs.isEmpty()) {
+            return TypeName.get(collectionType);
+        }
+
+        String rawTypeName = collectionType.toString();
+
+        if (rawTypeName.startsWith("java.util.List")) {
+            TypeName elementType = convertEntityTypeToDto(typeArgs.get(0), basePackage);
+            return ParameterizedTypeName.get(ClassName.get("java.util", "List"), elementType);
+        } else if (rawTypeName.startsWith("java.util.Set")) {
+            TypeName elementType = convertEntityTypeToDto(typeArgs.get(0), basePackage);
+            return ParameterizedTypeName.get(ClassName.get("java.util", "Set"), elementType);
+        } else if (rawTypeName.startsWith("java.util.Map")) {
+            TypeName keyType = convertEntityTypeToDto(typeArgs.get(0), basePackage);
+            TypeName valueType = typeArgs.size() > 1 ? convertEntityTypeToDto(typeArgs.get(1), basePackage) : TypeName.get(Object.class);
+            return ParameterizedTypeName.get(ClassName.get("java.util", "Map"), keyType, valueType);
+        }
+
+        return TypeName.get(collectionType);
+    }
 
 }

--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/PropertyGenerator.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/PropertyGenerator.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -330,6 +331,27 @@ public class PropertyGenerator {
         typeName.startsWith("java.util.Set") ||
         typeName.startsWith("java.util.Collection") ||
         typeName.startsWith("java.util.Map");
+  }
+
+  static boolean isEnumType(Element field) {
+    // Ensure the input is a field (for safety)
+    if (field.getKind() != ElementKind.FIELD) {
+      return false;
+    }
+
+    // Get the field's type
+    TypeMirror fieldType = field.asType();
+
+    // Check if it's a declared type (class/interface/enum)
+    if (fieldType.getKind() != TypeKind.DECLARED) {
+      return false;
+    }
+
+    // Get the element (class/interface/enum) of the field's type
+    Element typeElement = ((DeclaredType) fieldType).asElement();
+
+    // Check if it's an enum
+    return typeElement.getKind() == ElementKind.ENUM;
   }
 
   /**

--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/PropertyGenerator.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/PropertyGenerator.java
@@ -333,27 +333,6 @@ public class PropertyGenerator {
         typeName.startsWith("java.util.Map");
   }
 
-  static boolean isEnumType(Element field) {
-    // Ensure the input is a field (for safety)
-    if (field.getKind() != ElementKind.FIELD) {
-      return false;
-    }
-
-    // Get the field's type
-    TypeMirror fieldType = field.asType();
-
-    // Check if it's a declared type (class/interface/enum)
-    if (fieldType.getKind() != TypeKind.DECLARED) {
-      return false;
-    }
-
-    // Get the element (class/interface/enum) of the field's type
-    Element typeElement = ((DeclaredType) fieldType).asElement();
-
-    // Check if it's an enum
-    return typeElement.getKind() == ElementKind.ENUM;
-  }
-
   /**
    * Adds methods for manipulating collection fields.
    *

--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/annotations/Enums.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/annotations/Enums.java
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Dorin Brage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.eorghe.hyperapi.processor.annotations;
+/**
+ *
+ * @author Dorin Brage
+ * @version 0.3.0
+ * @since 0.3.0
+ */
+public @interface Enums {
+
+  /**
+   * Specifies the names of fields to ignore during mapping.
+   *
+   * @return an array of field names to ignore
+   */
+  String[] ignore() default {};
+
+}

--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/annotations/HyperResource.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/annotations/HyperResource.java
@@ -85,6 +85,8 @@ public @interface HyperResource {
    */
   HttpMethod[] disabledFor() default {};
 
+  String[] ignoreFields() default {};
+
   /**
    * Specifies the mapping configuration for the resource.
    *


### PR DESCRIPTION
## ✨ Generate DTOs from enum classes with 1:1 annotation and constant mapping


This PR introduces support for generating DTOs from `enum` classes with a 1:1 mapping of enum constants and their annotations.

### ✅ What's included:
- 🧩 Mirrors all class-level annotations to the generated enum DTO
- 🧩 Copies annotations on individual enum constants (e.g. `@JsonIgnore`)
- 🧩 Preserves enum constant names and ordering

### ⚠️ What's new with this PR - BONUS!
- 🧩 `@HyperResource.mapping(ignore = {...})` to skip selected fields from the JPA from being included in the generated DTO - Takes care of #64 

### 🔧 Why it matters:
This ensures the generated DTOs remain faithful to the source `enum`, while also giving developers full control over what should or shouldn't be exposed through DTOs — useful for fine-grained API exposure and Swagger/OpenAPI documentation accuracy.