### PR TITLE
Fixed #65

### DIFF
--- a/hyperapi/src/main/java/com/eorghe/hyperapi/processor/HyperApiProcessor.java
+++ b/hyperapi/src/main/java/com/eorghe/hyperapi/processor/HyperApiProcessor.java
@@ -826,9 +826,16 @@ public class HyperApiProcessor extends AbstractProcessor {
                                                 String entityName, TypeSpec.Builder serviceClass, ClassName entityClass,
                                                 HyperResource hyperResource) {
 
+        boolean isDefaulRepositoryPkgValue = hyperResource.repositoryPackage().equalsIgnoreCase("repository");
+        String pathRepository = hyperResource.repositoryPackage();
+
+        // override is not default.
+        if(isDefaulRepositoryPkgValue){
+            pathRepository = basePackage + "." + hyperResource.repositoryPackage();
+        }
+
         // Add injected repository field
-        ClassName repositoryClass = ClassName.get(basePackage + "." + hyperResource.repositoryPackage(),
-                entityName + "Repository");
+        ClassName repositoryClass = ClassName.get(pathRepository,entityName + "Repository");
         serviceClass.addField(FieldSpec.builder(repositoryClass, "repository", Modifier.PRIVATE)
                 .addAnnotation(ClassName.get("jakarta.inject", "Inject"))
                 .build());


### PR DESCRIPTION
## PR Description: Fix repositoryPackage path resolution in HyperResource

### \:bug: Problem

Previously, when specifying a custom `repositoryPackage` in `@HyperResource`, the annotation processor would always prepend the entity's base package, resulting in incorrect import paths like:

```
com.wordless.models.com.wordless.repository
```

### \:white\_check\_mark: Solution

This PR updates the `generateInjectRepository` method to correctly handle `repositoryPackage`:

* If the `repositoryPackage` is set to the default value (`"repository"`), the base package is prepended as before.
* If a custom value is provided, it is treated as an absolute package name and used as-is.

### \:wrench: Implementation

```java
boolean isDefaulRepositoryPkgValue = hyperResource.repositoryPackage().equalsIgnoreCase("repository");
String pathRepository = hyperResource.repositoryPackage();

if (isDefaulRepositoryPkgValue) {
    pathRepository = basePackage + "." + hyperResource.repositoryPackage();
}
```

This logic ensures that:

* `repositoryPackage = "repository"` → `basePackage.repository`
* `repositoryPackage = "com.foo.repo"` → `com.foo.repo`

### \:test\_tube: How to Test

* Annotate an entity with `@HyperResource(..., repositoryPackage = "com.wordless.repository")`
* Run `mvn clean install`
* Ensure the generated code imports from the correct repository path.

### \:memo: Changelog

* fix: support absolute repositoryPackage path resolution

---

Closes #65 
